### PR TITLE
ci: sitemap workflow + Cloudflare Pages config + icon cleanup

### DIFF
--- a/about.html
+++ b/about.html
@@ -41,7 +41,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon/favicon-32.png">
   <link rel="icon" type="image/x-icon" href="assets/favicon/favicon.ico">
   <link rel="manifest" href="assets/favicon/manifest.json">
-  <link rel="mask-icon" href="assets/favicon/safari-pinned-tab.svg" color="#5bbad5">
+  <!-- mask-icon removed: assets/favicon/safari-pinned-tab.svg not present -->
   <meta name="msapplication-TileColor" content="#da532c">
   <meta name="theme-color" content="#ffffff">
 

--- a/contact.html
+++ b/contact.html
@@ -140,7 +140,7 @@
       
       <!-- Downloadable vCard -->
       <p>
-        <a class="btn btn-primary" href="/assets/jgwalsh.vcf" download>Add to Contacts (.vcf)</a>
+  <a class="btn btn-primary" href="assets/jgwalsh.vcf" download>Add to Contacts (.vcf)</a>
       </p>
       
       <div class="border-t pt-6 text-center">

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon/favicon-32.png">
   <link rel="icon" type="image/x-icon" href="assets/favicon/favicon.ico">
   <link rel="manifest" href="assets/favicon/manifest.json">
-  <link rel="mask-icon" href="assets/favicon/safari-pinned-tab.svg" color="#5bbad5">
+  <!-- mask-icon removed: assets/favicon/safari-pinned-tab.svg not present -->
   <meta name="msapplication-TileColor" content="#da532c">
   <meta name="theme-color" content="#ffffff">
 

--- a/pages.toml
+++ b/pages.toml
@@ -1,9 +1,7 @@
 # Cloudflare Pages configuration
 
 [build]
-# Change this command and directory to match your framework
-command = "npm run build"
-directory = "dist"
+# No build command or directory needed for static HTML site
 
 [env.production]
 # Only deploy from the main branch

--- a/pages.toml
+++ b/pages.toml
@@ -1,0 +1,17 @@
+# Cloudflare Pages configuration
+
+[build]
+command = "npm run build"
+# or your actual build command, e.g. "astro build" / "next build" / "hugo" / etc.
+directory = "dist"   # change to "build" or "." if your output folder is different
+
+[env.production]
+# This ensures only the main branch deploys to production
+branch = "main"
+
+[env.preview]
+# Disable previews entirely
+branch = ""
+
+# Optional: if you want staging but not all branches, replace "" with explicit branch
+# branch = "staging"

--- a/pages.toml
+++ b/pages.toml
@@ -1,17 +1,14 @@
 # Cloudflare Pages configuration
 
 [build]
+# Change this command and directory to match your framework
 command = "npm run build"
-# or your actual build command, e.g. "astro build" / "next build" / "hugo" / etc.
-directory = "dist"   # change to "build" or "." if your output folder is different
+directory = "dist"
 
 [env.production]
-# This ensures only the main branch deploys to production
+# Only deploy from the main branch
 branch = "main"
 
 [env.preview]
 # Disable previews entirely
 branch = ""
-
-# Optional: if you want staging but not all branches, replace "" with explicit branch
-# branch = "staging"

--- a/project-crime-analysis.html
+++ b/project-crime-analysis.html
@@ -7,11 +7,11 @@
   <meta name="description" content="An advanced, interactive dashboard analyzing Albany, NY crime data (2021-2024) using time-series, hierarchical, and flow visualizations." />
   <meta name="robots" content="index, follow" />
 
-  <link rel="apple-touch-icon" sizes="180x180" href="assets/favicon/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon/favicon-16x16.png">
-  <link rel="manifest" href="assets/favicon/site.webmanifest">
-  <link rel="mask-icon" href="assets/favicon/safari-pinned-tab.svg" color="#5bbad5">
+  <link rel="apple-touch-icon" sizes="180x180" href="assets/favicon/favicon-180-precomposed.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon/favicon-32.png">
+  <!-- 16x16 favicon missing; generate one or adjust as needed -->
+  <link rel="manifest" href="assets/favicon/manifest.json">
+  <!-- mask-icon removed: assets/favicon/safari-pinned-tab.svg not present -->
   <meta name="msapplication-TileColor" content="#da532c">
   <meta name="theme-color" content="#ffffff">
 

--- a/projects.html
+++ b/projects.html
@@ -55,7 +55,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon/favicon-32.png">
   <link rel="icon" type="image/x-icon" href="assets/favicon/favicon.ico">
   <link rel="manifest" href="assets/favicon/manifest.json">
-  <link rel="mask-icon" href="assets/favicon/safari-pinned-tab.svg" color="#5bbad5">
+  <!-- mask-icon removed: assets/favicon/safari-pinned-tab.svg not present -->
   <meta name="msapplication-TileColor" content="#da532c">
   <meta name="theme-color" content="#ffffff">
 

--- a/verification.html
+++ b/verification.html
@@ -135,7 +135,7 @@
 <body>
   <div class="window">
     <!-- Retro title bar -->
-    <div class="title-bar"><img src="/assets/icons/use-jobs.svg" alt="Verification Icon" width="24" height="24" style="vertical-align:middle;margin-right:8px;">Verified Credentials – J. Gregory Walsh</div>
+  <div class="title-bar"><img src="assets/icons/use-jobs.svg" alt="Verification Icon" width="24" height="24" style="vertical-align:middle;margin-right:8px;">Verified Credentials – J. Gregory Walsh</div>
 
     <div class="content">
       <!-- LinkedIn Badge -->
@@ -181,7 +181,7 @@
 
       <!-- Screenshot for visual proof -->
       <figure>
-        <img src="/assets/linkedin-verification.png"
+  <img src="assets/linkedin-verification.png"
              alt="LinkedIn verification screenshot showing education and identity badges"
              style="width:100%;border:1px solid #999;">
         <figcaption>LinkedIn “Verifications” panel as of 2025‑08‑01</figcaption>


### PR DESCRIPTION
### Summary
- Add Cloudflare Pages configuration (`pages.toml`) to deploy only from `main`.
- Add `_headers` with CSP that allows Google Fonts, Tailwind CDN, jsDelivr, and Cloudflare beacon so styles/scripts load.
- Remove broken mask-icon references and unused assets.
- Fix asset paths/case where needed.

### Why
- Stop automatic preview deploys and keep production-only builds clean.
- Resolve CSP errors blocking CSS/JS/fonts and restore site styling.
- Avoid 404s from missing icons.

### Changes
- `pages.toml` — set build dir and restrict envs.
- `_headers` — explicit CSP + security headers.
- `about.html`, `contact.html`, `index.html`, etc. — remove bad icons/paths.
- asset cleanups.

### Checklist
- [ ] Pages build succeeds on PR
- [ ] No CSP errors in console on preview deploy
- [ ] CSS/JS load (200 + correct MIME)
- [ ] Icons render; no 404s